### PR TITLE
Added compatibility with multi-root workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "copy-python-dotted-path",
   "displayName": "Copy Python Path",
   "description": "Copy python dotted path to clipboard",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "repository": "https://github.com/kawamataryo/copy-python-path",
   "publisher": "kawamataryo",
   "icon": "images/icon.png",
@@ -11,7 +11,8 @@
     "path",
     "unittest",
     "copy",
-    "clipboard"
+    "clipboard",
+    "multi-root ready"
   ],
   "engines": {
     "vscode": "^1.65.0"
@@ -86,7 +87,7 @@
     "typescript": "^4.5.5",
     "vsce": "^2.7.0",
     "webpack": "^5.70.0",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "dt-python-parser": "^0.9.2-beta"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "onCommand:copy-python-path.copy-python-path"
+    "onCommand:copy-python-path.copy-python-path",
+    "onCommand:copy-python-import-statement"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -33,6 +34,10 @@
       {
         "command": "copy-python-path.copy-python-path",
         "title": "Copy python path"
+      },
+      {
+        "command": "copy-python-path.copy-python-import-statement",
+        "title": "Copy python import statement"
       }
     ],
     "menus": {
@@ -41,12 +46,22 @@
           "when": "resourceLangId == python",
           "command": "copy-python-path.copy-python-path",
           "group": "myGroup@1"
+        },
+        {
+          "when": "resourceLangId == python",
+          "command": "copy-python-path.copy-python-import-statement",
+          "group": "myGroup@1"
         }
       ],
       "explorer/context": [
         {
           "when": "resourceLangId == python",
           "command": "copy-python-path.copy-python-path",
+          "group": "myGroup@1"
+        },
+        {
+          "when": "resourceLangId == python",
+          "command": "copy-python-path.copy-python-import-statement",
           "group": "myGroup@1"
         }
       ]
@@ -56,6 +71,12 @@
         "command": "copy-python-path.copy-python-path",
         "key": "option+ctrl+c",
         "mac": "option+cmd+c",
+        "when": "editorTextFocus && resourceLangId == python"
+      },
+      {
+        "command": "copy-python-path.copy-python-import-statement",
+        "key": "option+ctrl+shift+c",
+        "mac": "option+cmd+shift+c",
         "when": "editorTextFocus && resourceLangId == python"
       }
     ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,44 +1,71 @@
 import * as vscode from 'vscode';
+import { basename } from 'path';
 import { getRelatedDefinedSymbols } from './utils/getRelatedDefinedSymbols';
 import { getCurrentFileDottedPath } from './utils/getCurrentFileDottedPath';
 
 
 export function activate(context: vscode.ExtensionContext) {
   const disposable = vscode.commands.registerCommand('copy-python-path.copy-python-path', async () => {
-    const currentFilePath = vscode.window.activeTextEditor?.document.fileName;
 
-    if (!currentFilePath) {
-      vscode.window.showErrorMessage("Don't read file. only use this command when selected file.");
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+      vscode.window.showErrorMessage("No active editor! Only use this command when selected file in active editor.");
       return;
     }
 
-    if (!/.py$/.test(currentFilePath)) {
-      vscode.window.showErrorMessage('Not a python file. only use this command when selected python file.');
-      return;
+    
+
+    // New resource method
+    const resource = editor.document.uri;
+    if (resource.scheme === 'file') {
+        const currentFilePath = editor.document.fileName;
+        if (!currentFilePath) {
+          vscode.window.showErrorMessage("Don't read file. only use this command when selected file.");
+          return;
+        }
+        if (!/.py$/.test(currentFilePath)) {
+          vscode.window.showErrorMessage('Not a python file. only use this command when selected python file.');
+          return;
+        }
+        // Get workspace folder to determine relative path
+        const folder = vscode.workspace.getWorkspaceFolder(resource);
+        if (!folder) {
+            vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
+            return;
+            // text = `$(alert) <outside workspace> → ${basename(resource.fsPath)}`;
+        } else {
+              const moduleRootName = basename(folder.uri.fsPath);
+               // get current file dotted path
+              const currentFileDottedPath = [moduleRootName, getCurrentFileDottedPath(folder.uri.fsPath, currentFilePath)].join('.'); // Add the moduleRootName (package name) to the start
+              try {
+                // get related defined symbols from current file and current cursor position
+                const text = vscode.window.activeTextEditor!.document.getText();
+                const currentLine = vscode.window.activeTextEditor!.selection.active.line;
+                const definedSymbols = getRelatedDefinedSymbols(text, currentLine + 1);
+                const finalOutPath = [currentFileDottedPath, ...definedSymbols].join('.');
+                // copy python dotted path to clipboard
+                await vscode.env.clipboard.writeText(finalOutPath);
+                // vscode.window.showInformationMessage('Copied to clipboard.');
+                vscode.window.showInformationMessage(['Copied to clipboard', finalOutPath].join(': '));
+              } catch (e) {
+                console.error(e);
+                vscode.window.showErrorMessage('Failed to parse file.');
+              }
+            // text = `$(file-submodule) ${basename(folder.uri.fsPath)} (${folder.index + 1} of ${vscode.workspace.workspaceFolders.length}) → $(file-code) ${basename(resource.fsPath)}`;
+            // tooltip = resource.fsPath;
+
+            // const multiRootConfigForResource = vscode.workspace.getConfiguration('multiRootSample', resource);
+            // color = multiRootConfigForResource.get('statusColor');
+        }
     }
 
-    const folders = vscode.workspace.workspaceFolders;
-    if(!folders) {
-      vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
-      return;
-    }
-
-    // get current file dotted path
-    const currentFileDottedPath = getCurrentFileDottedPath(folders[0].uri.fsPath, currentFilePath);
-
-    try {
-      // get related defined symbols from current file and current cursor position
-      const text = vscode.window.activeTextEditor!.document.getText();
-      const currentLine = vscode.window.activeTextEditor!.selection.active.line;
-      const definedSymbols = getRelatedDefinedSymbols(text, currentLine + 1);
-
-      // copy python dotted path to clipboard
-      await vscode.env.clipboard.writeText([currentFileDottedPath, ...definedSymbols].join('.'));
-      vscode.window.showInformationMessage('Copied to clipboard.');
-    } catch (e) {
-      console.error(e);
-      vscode.window.showErrorMessage('Failed to parse file.');
-    }
+    // old method:
+    // const folders = vscode.workspace.workspaceFolders;
+    // if(!folders) {
+    //   vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
+    //   return;
+    // }
   });
 
   context.subscriptions.push(disposable);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,15 +8,59 @@ export function activate(context: vscode.ExtensionContext) {
   const disposable = vscode.commands.registerCommand('copy-python-path.copy-python-path', async () => {
 
     const editor = vscode.window.activeTextEditor;
-
     if (!editor) {
       vscode.window.showErrorMessage("No active editor! Only use this command when selected file in active editor.");
       return;
     }
 
-    
+    const resource = editor.document.uri;
+    if (resource.scheme === 'file') {
+        const currentFilePath = editor.document.fileName;
+        if (!currentFilePath) {
+          vscode.window.showErrorMessage("Don't read file. only use this command when selected file.");
+          return;
+        }
+        if (!/.py$/.test(currentFilePath)) {
+          vscode.window.showErrorMessage('Not a python file. only use this command when selected python file.');
+          return;
+        }
+        // Get workspace folder to determine relative path
+        const folder = vscode.workspace.getWorkspaceFolder(resource);
+        if (!folder) {
+            vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
+            return;
+        } else {
+              const moduleRootName = basename(folder.uri.fsPath);
+               // get current file dotted path
+              const currentFileDottedPath = [moduleRootName, getCurrentFileDottedPath(folder.uri.fsPath, currentFilePath)].join('.'); // Add the moduleRootName (package name) to the start
+              try {
+                // get related defined symbols from current file and current cursor position
+                const text = vscode.window.activeTextEditor!.document.getText();
+                const currentLine = vscode.window.activeTextEditor!.selection.active.line;
+                const definedSymbols = getRelatedDefinedSymbols(text, currentLine + 1);
+                const finalOutPath = [currentFileDottedPath, ...definedSymbols].join('.');
+                // copy python dotted path to clipboard
+                await vscode.env.clipboard.writeText(finalOutPath);
+                // vscode.window.showInformationMessage('Copied to clipboard.');
+                vscode.window.showInformationMessage(['Copied to clipboard', finalOutPath].join(': '));
+              } catch (e) {
+                console.error(e);
+                vscode.window.showErrorMessage('Failed to parse file.');
+              }
+        }
+    }
 
-    // New resource method
+  });
+  context.subscriptions.push(disposable);
+
+  const disposable2 = vscode.commands.registerCommand('copy-python-path.copy-python-import-statement', async () => {
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showErrorMessage("No active editor! Only use this command when selected file in active editor.");
+      return;
+    }
+
     const resource = editor.document.uri;
     if (resource.scheme === 'file') {
         const currentFilePath = editor.document.fileName;
@@ -43,32 +87,24 @@ export function activate(context: vscode.ExtensionContext) {
                 const text = vscode.window.activeTextEditor!.document.getText();
                 const currentLine = vscode.window.activeTextEditor!.selection.active.line;
                 const definedSymbols = getRelatedDefinedSymbols(text, currentLine + 1);
-                const finalOutPath = [currentFileDottedPath, ...definedSymbols].join('.');
+                const finalOutPath = currentFileDottedPath;
+                const finalImportStatement = `from ${finalOutPath} import ${definedSymbols.join(', ')}`;
+
                 // copy python dotted path to clipboard
-                await vscode.env.clipboard.writeText(finalOutPath);
+                await vscode.env.clipboard.writeText(finalImportStatement);
                 // vscode.window.showInformationMessage('Copied to clipboard.');
-                vscode.window.showInformationMessage(['Copied to clipboard', finalOutPath].join(': '));
+                vscode.window.showInformationMessage(['Copied to clipboard', finalImportStatement].join(': '));
               } catch (e) {
                 console.error(e);
                 vscode.window.showErrorMessage('Failed to parse file.');
               }
-            // text = `$(file-submodule) ${basename(folder.uri.fsPath)} (${folder.index + 1} of ${vscode.workspace.workspaceFolders.length}) → $(file-code) ${basename(resource.fsPath)}`;
-            // tooltip = resource.fsPath;
-
-            // const multiRootConfigForResource = vscode.workspace.getConfiguration('multiRootSample', resource);
-            // color = multiRootConfigForResource.get('statusColor');
         }
     }
 
-    // old method:
-    // const folders = vscode.workspace.workspaceFolders;
-    // if(!folders) {
-    //   vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
-    //   return;
-    // }
   });
+  context.subscriptions.push(disposable2);
 
-  context.subscriptions.push(disposable);
+
 }
 
 export function deactivate() { }

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,22 +342,22 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz"
-  integrity sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==
+"@webpack-cli/configtest@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.2.0.tgz#7b20ce1c12533912c3b217ea68262365fa29a6f5"
+  integrity sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
 
-"@webpack-cli/info@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.1.tgz"
-  integrity sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==
+"@webpack-cli/info@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.5.0.tgz#6c78c13c5874852d6e2dd17f08a41f3fe4c261b1"
+  integrity sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz"
-  integrity sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==
+"@webpack-cli/serve@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
+  integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -1075,21 +1075,6 @@ events@^3.2.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
-  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.0"
-    human-signals "^2.1.0"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.1"
-    onetime "^5.1.2"
-    signal-exit "^3.0.3"
-    strip-final-newline "^2.0.0"
-
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
@@ -1251,11 +1236,6 @@ get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-stream@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
-  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
-
 github-from-package@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
@@ -1387,11 +1367,6 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-human-signals@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
-  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -1500,11 +1475,6 @@ is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
-
-is-stream@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
-  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-unicode-supported@^0.1.0:
   version "0.1.0"
@@ -1685,11 +1655,6 @@ mime@^1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mimic-fn@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -1813,13 +1778,6 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-npm-run-path@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
-  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  dependencies:
-    path-key "^3.0.0"
-
 npmlog@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -1858,13 +1816,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-onetime@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
-  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  dependencies:
-    mimic-fn "^2.1.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -1947,7 +1898,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^3.0.0, path-key@^3.1.0:
+path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -2241,7 +2192,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.3:
+signal-exit@^3.0.0:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -2328,11 +2279,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-final-newline@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
-  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -2588,18 +2534,18 @@ watchpack@^2.3.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webpack-cli@^4.9.2:
-  version "4.9.2"
-  resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz"
-  integrity sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+webpack-cli@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
+  integrity sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^1.1.1"
-    "@webpack-cli/info" "^1.4.1"
-    "@webpack-cli/serve" "^1.6.1"
+    "@webpack-cli/configtest" "^1.2.0"
+    "@webpack-cli/info" "^1.5.0"
+    "@webpack-cli/serve" "^1.7.0"
     colorette "^2.0.14"
     commander "^7.0.0"
-    execa "^5.0.0"
+    cross-spawn "^7.0.3"
     fastest-levenshtein "^1.0.12"
     import-local "^3.0.2"
     interpret "^2.2.0"


### PR DESCRIPTION
Previously for multi-root workspaces, it was returning dotted absolute paths like: ":.Users.pho.repos.pyPhoPlaceCellAnalysis.src.pyphoplacecellanalysis.GUI.PyQtPlot.Widgets.DockAreaWrapper.NestedDockAreaWidget"

After this update, it returns the expected relative dotted path: "pyphoplacecellanalysis.GUI.PyQtPlot.Widgets.DockAreaWrapper.NestedDockAreaWidget"

This was accomplished by implementing multi-root workspace support as outlined in 
https://github.com/microsoft/vscode/wiki/Adopting-Multi-Root-Workspace-APIs
https://code.visualstudio.com/docs/editor/multi-root-workspaces

I also added a convenience functionality to generate and copy valid Python import statements for the active symbols.
For the same class this would return:
"from pyphoplacecellanalysis.GUI.PyQtPlot.Widgets.DockAreaWrapper import NestedDockAreaWidget"






