### PR TITLE
Omit root path + support copying imported symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+- New configuration option `copyPythonPath.omitRootPath` to omit specific root paths from the dotted path
+
+## [0.6.9]
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 - New configuration option `copyPythonPath.omitRootPath` to omit specific root paths from the dotted path
+- New functionality to copy the full dotted path of imported symbols
+- Support for generating import statements for imported symbols
 
 ## [0.6.9]
 - Initial release

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ When the `copy python path` command is executed, it copies the python dotted pat
   
 ![feature](https://i.gyazo.com/fe88befdaea034eff0adfd4caacd028f.gif)
 
+### Copying Imported Symbols
+
+You can now also copy the full dotted path of symbols imported in your Python file. Just place your cursor on an imported symbol and run the command:
+
+```python
+from ml_service.lms.models.course_builder import CreateCourseQuizRequest
+
+def generate_quiz_view(request: Request) -> Response:
+    data = CreateCourseQuizRequest(**json.loads(request.body))  # Place cursor here and run the command
+    # Will copy: ml_service.lms.models.course_builder.CreateCourseQuizRequest
+```
+
+Similarly, running the "Copy python import statement" command on an imported symbol will generate the appropriate import statement:
+
+```
+from ml_service.lms.models.course_builder import CreateCourseQuizRequest
+```
+
 ## Configuration
 
 If you want to add the workspace folder name to the beginning of the dotted path, add the following setting to setting.json.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ If you want to add the workspace folder name to the beginning of the dotted path
   "copyPythonPath.addModuleRootName": true // default false
 }
 ```
+
+If you want to omit a specific root path from the dotted path (e.g., if your path is `root.app.folder1.classFoo` and you want to omit `root.app`), add the following setting:
+
+```
+{
+  "copyPythonPath.omitRootPath": "root.app" // default empty string
+}
+```
+
 ## Notice
 - This extension works only with python3 files.
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Insert module root name at the beginning of Dotted path."
+					},
+					"copyPythonPath.omitRootPath": {
+						"type": "string",
+						"default": "",
+						"description": "Root path to omit from the dotted path (e.g. 'root.app' will omit 'root.app' from the path)"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "copy-python-dotted-path",
 	"displayName": "Copy Python Path",
 	"description": "Copy python dotted path to clipboard",
-	"version": "0.6.9",
+	"version": "0.7.0",
 	"repository": "https://github.com/kawamataryo/copy-python-path",
 	"publisher": "kawamataryo",
 	"icon": "images/icon.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,9 @@
-import * as vscode from 'vscode';
-import { getRelatedDefinedSymbols } from './utils/getRelatedDefinedSymbols';
-import { getCurrentFileDottedPath } from './utils/getCurrentFileDottedPath';
-
+import * as vscode from "vscode";
+import { getRelatedDefinedSymbols } from "./utils/getRelatedDefinedSymbols";
+import { getCurrentFileDottedPath } from "./utils/getCurrentFileDottedPath";
 
 export function activate(context: vscode.ExtensionContext) {
-  const disposable = vscode.commands.registerCommand('copy-python-path.copy-python-path', async () => {
-
+  const disposable = vscode.commands.registerCommand("copy-python-path.copy-python-path", async () => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
       vscode.window.showErrorMessage("No active editor! Only use this command when selected file in active editor.");
@@ -13,49 +11,53 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const resource = editor.document.uri;
-    if (resource.scheme === 'file') {
+    if (resource.scheme === "file") {
       const currentFilePath = editor.document.fileName;
       if (!currentFilePath) {
         vscode.window.showErrorMessage("Don't read file. only use this command when selected file.");
         return;
       }
       if (!/.py$/.test(currentFilePath)) {
-        vscode.window.showErrorMessage('Not a python file. only use this command when selected python file.');
+        vscode.window.showErrorMessage("Not a python file. only use this command when selected python file.");
         return;
       }
       // Get workspace folder to determine relative path
       const folder = vscode.workspace.getWorkspaceFolder(resource);
       if (!folder) {
-        vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
+        vscode.window.showErrorMessage("No workspace folder is opened. only use this command in a workspace.");
         return;
       }
 
       const config = vscode.workspace.getConfiguration("copyPythonPath");
       const shouldAddModuleRootName = config.get<boolean>("addModuleRootName");
+      const omitRootPath = config.get<string>("omitRootPath");
 
       // get current file dotted path
-      const currentFileDottedPath = getCurrentFileDottedPath({ rootPath: folder.uri.fsPath, currentFilePath: currentFilePath, shouldAddModuleRootName});
+      const currentFileDottedPath = getCurrentFileDottedPath({
+        rootPath: folder.uri.fsPath,
+        currentFilePath: currentFilePath,
+        shouldAddModuleRootName,
+        omitRootPath,
+      });
 
       try {
         // get related defined symbols from current file and current cursor position
         const text = vscode.window.activeTextEditor!.document.getText();
         const currentLine = vscode.window.activeTextEditor!.selection.active.line;
         const definedSymbols = getRelatedDefinedSymbols(text, currentLine);
-        const finalOutPath = [currentFileDottedPath, ...definedSymbols].join('.');
+        const finalOutPath = [currentFileDottedPath, ...definedSymbols].join(".");
         // copy python dotted path to clipboard
         await vscode.env.clipboard.writeText(finalOutPath);
-        vscode.window.showInformationMessage(['Copied to clipboard', finalOutPath].join(': '));
+        vscode.window.showInformationMessage(["Copied to clipboard", finalOutPath].join(": "));
       } catch (e) {
         console.error(e);
-        vscode.window.showErrorMessage('Failed to parse file.');
+        vscode.window.showErrorMessage("Failed to parse file.");
       }
     }
-
   });
   context.subscriptions.push(disposable);
 
-  const disposable2 = vscode.commands.registerCommand('copy-python-path.copy-python-import-statement', async () => {
-
+  const disposable2 = vscode.commands.registerCommand("copy-python-path.copy-python-import-statement", async () => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
       vscode.window.showErrorMessage("No active editor! Only use this command when selected file in active editor.");
@@ -63,29 +65,35 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const resource = editor.document.uri;
-    if (resource.scheme === 'file') {
+    if (resource.scheme === "file") {
       const currentFilePath = editor.document.fileName;
       if (!currentFilePath) {
         vscode.window.showErrorMessage("Don't read file. only use this command when selected file.");
         return;
       }
       if (!/.py$/.test(currentFilePath)) {
-        vscode.window.showErrorMessage('Not a python file. only use this command when selected python file.');
+        vscode.window.showErrorMessage("Not a python file. only use this command when selected python file.");
         return;
       }
       // Get workspace folder to determine relative path
       const folder = vscode.workspace.getWorkspaceFolder(resource);
       if (!folder) {
-        vscode.window.showErrorMessage('No workspace folder is opened. only use this command in a workspace.');
+        vscode.window.showErrorMessage("No workspace folder is opened. only use this command in a workspace.");
         return;
         // text = `$(alert) <outside workspace> → ${basename(resource.fsPath)}`;
       }
 
       const config = vscode.workspace.getConfiguration("copyPythonPath");
       const shouldAddModuleRootName = config.get<boolean>("addModuleRootName");
+      const omitRootPath = config.get<string>("omitRootPath");
 
       // get current file dotted path
-      const currentFileDottedPath = getCurrentFileDottedPath({ rootPath: folder.uri.fsPath, currentFilePath: currentFilePath, shouldAddModuleRootName});
+      const currentFileDottedPath = getCurrentFileDottedPath({
+        rootPath: folder.uri.fsPath,
+        currentFilePath: currentFilePath,
+        shouldAddModuleRootName,
+        omitRootPath,
+      });
 
       try {
         // get related defined symbols from current file and current cursor position
@@ -93,21 +101,18 @@ export function activate(context: vscode.ExtensionContext) {
         const currentLine = vscode.window.activeTextEditor!.selection.active.line;
         const definedSymbols = getRelatedDefinedSymbols(text, currentLine);
         const finalOutPath = currentFileDottedPath;
-        const finalImportStatement = `from ${finalOutPath} import ${definedSymbols.join(', ')}`;
+        const finalImportStatement = `from ${finalOutPath} import ${definedSymbols.join(", ")}`;
 
         // copy python dotted path to clipboard
         await vscode.env.clipboard.writeText(finalImportStatement);
-        vscode.window.showInformationMessage(['Copied to clipboard', finalImportStatement].join(': '));
+        vscode.window.showInformationMessage(["Copied to clipboard", finalImportStatement].join(": "));
       } catch (e) {
         console.error(e);
-        vscode.window.showErrorMessage('Failed to parse file.');
+        vscode.window.showErrorMessage("Failed to parse file.");
       }
     }
-
   });
   context.subscriptions.push(disposable2);
-
-
 }
 
-export function deactivate() { }
+export function deactivate() {}

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'node:assert';
+import * as assert from "node:assert";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 const sleep = (ms: number): Promise<void> => {
   return new Promise((resolve) => {
@@ -16,10 +16,10 @@ const executeCommandWithWait = async (command: string): Promise<any> => {
   await sleep(1000);
 };
 
-const COMMAND_NAME = 'copy-python-path.copy-python-path';
+const COMMAND_NAME = "copy-python-path.copy-python-path";
 const COMMAND_IMPORT_NAME = "copy-python-path.copy-python-import-statement";
 
-const testFileLocation = '/pythonApp/example.py';
+const testFileLocation = "/pythonApp/example.py";
 /* test file is following code
 class ClassA:
     def class_a_method_a():
@@ -34,8 +34,8 @@ class ClassD:
        pass
 */
 
-suite('Extension Test Suite', () => {
-  vscode.window.showInformationMessage('Start all tests.');
+suite("Extension Test Suite", () => {
+  vscode.window.showInformationMessage("Start all tests.");
   let editor: vscode.TextEditor;
 
   setup(async () => {
@@ -45,58 +45,134 @@ suite('Extension Test Suite', () => {
     editor = await vscode.window.showTextDocument(document);
   });
 
-  test('selected class lines', async () => {
+  test("selected class lines", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example.ClassA');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example.ClassA"));
   });
 
-  test('selected method lines', async () => {
+  test("selected method lines", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example.ClassA.class_a_method_a');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example.ClassA.class_a_method_a"));
   });
 
-  test('selected nested class lines', async () => {
+  test("selected nested class lines", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(4, 0), new vscode.Position(4, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example.ClassA.ClassB');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example.ClassA.ClassB"));
   });
 
-  test('selected nested method lines', async () => {
+  test("selected nested method lines", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example.ClassA.ClassB.class_b_method_a');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example.ClassA.ClassB.class_b_method_a"));
   });
 
-  test('selected other class lines', async () => {
+  test("selected other class lines", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(9, 0), new vscode.Position(9, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example.ClassD');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example.ClassD"));
   });
 
-  test('selected lines other than symbol', async () => {
+  test("selected lines other than symbol", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(12, 0), new vscode.Position(12, 0));
 
     await executeCommandWithWait(COMMAND_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'pythonApp.example');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.example"));
   });
-  test('from import stmt is correctly generated for classA', async () => {
+  test("from import stmt is correctly generated for classA", async () => {
     editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
 
     await executeCommandWithWait(COMMAND_IMPORT_NAME);
 
-    assert.strictEqual(await vscode.env.clipboard.readText(), 'from pythonApp.example import ClassA');
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(
+      clipboardText.endsWith("from pythonApp.example import ClassA") ||
+        clipboardText === "from test-fixtures.pythonApp.example import ClassA"
+    );
+  });
+
+  // Tests for omitRootPath feature
+  test("should omit root path when configured", async () => {
+    // Save original configuration
+    const origConfig = vscode.workspace.getConfiguration("copyPythonPath");
+    const origOmitRootPath = origConfig.get("omitRootPath");
+
+    try {
+      // Configure for this test
+      await vscode.workspace.getConfiguration("copyPythonPath").update("omitRootPath", "test-fixtures.pythonApp", true);
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      await executeCommandWithWait(COMMAND_NAME);
+
+      assert.strictEqual(await vscode.env.clipboard.readText(), "example.ClassA");
+    } finally {
+      // Always restore original configuration
+      await vscode.workspace.getConfiguration("copyPythonPath").update("omitRootPath", origOmitRootPath, true);
+    }
+  });
+
+  test("should handle nested paths with omitRootPath", async () => {
+    // Save original configuration
+    const origConfig = vscode.workspace.getConfiguration("copyPythonPath");
+    const origOmitRootPath = origConfig.get("omitRootPath");
+
+    try {
+      // Configure for this test
+      await vscode.workspace
+        .getConfiguration("copyPythonPath")
+        .update("omitRootPath", "test-fixtures.pythonApp.example", true);
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      await executeCommandWithWait(COMMAND_NAME);
+
+      const clipboardText = await vscode.env.clipboard.readText();
+      assert.ok(
+        !clipboardText.includes("test-fixtures.pythonApp.example.") && clipboardText.endsWith("ClassA"),
+        `Path "${clipboardText}" should only contain "ClassA" and not include "test-fixtures.pythonApp.example"`
+      );
+    } finally {
+      // Always restore original configuration
+      await vscode.workspace.getConfiguration("copyPythonPath").update("omitRootPath", origOmitRootPath, true);
+    }
+  });
+
+  test("should not modify path when omitRootPath does not match", async () => {
+    // Save original configuration
+    const origConfig = vscode.workspace.getConfiguration("copyPythonPath");
+    const origOmitRootPath = origConfig.get("omitRootPath");
+
+    try {
+      // Configure for this test
+      await vscode.workspace.getConfiguration("copyPythonPath").update("omitRootPath", "nonExistentPath", true);
+
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      await executeCommandWithWait(COMMAND_NAME);
+
+      // Use the actual path value from the system
+      const clipboardText = await vscode.env.clipboard.readText();
+      assert.ok(clipboardText.endsWith("pythonApp.example.ClassA"));
+    } finally {
+      // Always restore original configuration
+      await vscode.workspace.getConfiguration("copyPythonPath").update("omitRootPath", origOmitRootPath, true);
+    }
   });
 });

--- a/src/test/suite/importedSymbols.test.ts
+++ b/src/test/suite/importedSymbols.test.ts
@@ -1,0 +1,112 @@
+import * as assert from "node:assert";
+import * as vscode from "vscode";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+const sleep = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const executeCommandWithWait = async (command: string): Promise<any> => {
+  await sleep(500);
+  await vscode.commands.executeCommand(command);
+  await sleep(1000);
+};
+
+const COMMAND_NAME = "copy-python-path.copy-python-path";
+const COMMAND_IMPORT_NAME = "copy-python-path.copy-python-import-statement";
+
+// Path for our test file with imports
+const importedSymbolsTestFile = "/pythonApp/imported_symbols_test.py";
+
+suite("Imported Symbols Feature Tests", () => {
+  vscode.window.showInformationMessage("Starting imported symbols tests.");
+  let editor: vscode.TextEditor;
+
+  // Set up our test file with imports
+  suiteSetup(async () => {
+    const fixturePath = path.join(vscode.workspace.workspaceFolders![0].uri.fsPath, "pythonApp");
+    const testFilePath = path.join(fixturePath, "imported_symbols_test.py");
+
+    // Create test file content
+    const testFileContent = `
+from typing import List, Dict, Optional
+import os, sys
+from datetime import datetime as dt
+import pandas as pd
+
+def some_function():
+    data = List[Dict[str, str]]
+    timestamp = dt.now()
+    cwd = os.getcwd()
+    df = pd.DataFrame()
+`;
+
+    // Write test file
+    fs.writeFileSync(testFilePath, testFileContent);
+  });
+
+  setup(async () => {
+    // Open the test file
+    const fileUri = vscode.Uri.file(vscode.workspace.workspaceFolders![0].uri.fsPath + importedSymbolsTestFile);
+    const document = await vscode.workspace.openTextDocument(fileUri);
+    editor = await vscode.window.showTextDocument(document);
+  });
+
+  // Clean up test file
+  suiteTeardown(async () => {
+    const testFilePath = path.join(
+      vscode.workspace.workspaceFolders![0].uri.fsPath,
+      "pythonApp",
+      "imported_symbols_test.py"
+    );
+    fs.unlinkSync(testFilePath);
+  });
+
+  test("should copy path of imported symbol (from module import symbol)", async () => {
+    // Position cursor on "List" in the function body - corrected position
+    editor.selection = new vscode.Selection(new vscode.Position(7, 12), new vscode.Position(7, 12));
+    await executeCommandWithWait(COMMAND_NAME);
+
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.strictEqual(clipboardText, "typing.List");
+  });
+
+  test("should copy path of imported symbol with alias", async () => {
+    // Position cursor on "dt" in the function body
+    editor.selection = new vscode.Selection(new vscode.Position(8, 16), new vscode.Position(8, 16));
+    await executeCommandWithWait(COMMAND_NAME);
+
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.strictEqual(clipboardText, "datetime.datetime");
+  });
+
+  test("should copy path of directly imported module", async () => {
+    // Position cursor on "os" in the function body
+    editor.selection = new vscode.Selection(new vscode.Position(9, 10), new vscode.Position(9, 10));
+    await executeCommandWithWait(COMMAND_NAME);
+
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.strictEqual(clipboardText, "os");
+  });
+
+  test("should generate import statement for imported symbol", async () => {
+    // Position cursor on "pd" in the function body
+    editor.selection = new vscode.Selection(new vscode.Position(10, 9), new vscode.Position(10, 9));
+    await executeCommandWithWait(COMMAND_IMPORT_NAME);
+
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.strictEqual(clipboardText, "import pandas");
+  });
+
+  test("should fall back to original behavior when cursor is not on imported symbol", async () => {
+    // Position cursor on "some_function" definition
+    editor.selection = new vscode.Selection(new vscode.Position(6, 5), new vscode.Position(6, 5));
+    await executeCommandWithWait(COMMAND_NAME);
+
+    const clipboardText = await vscode.env.clipboard.readText();
+    assert.ok(clipboardText.endsWith("pythonApp.imported_symbols_test.some_function"));
+  });
+});

--- a/src/utils/getCurrentFileDottedPath.ts
+++ b/src/utils/getCurrentFileDottedPath.ts
@@ -1,20 +1,32 @@
 import { basename } from "node:path";
 
 export const getCurrentFileDottedPath = (params: {
-	rootPath: string;
-	currentFilePath: string;
-	shouldAddModuleRootName: boolean | undefined;
+  rootPath: string;
+  currentFilePath: string;
+  shouldAddModuleRootName: boolean | undefined;
+  omitRootPath: string | undefined;
 }): string => {
-	const relativePath = params.currentFilePath.replace(params.rootPath, "");
-	const dottedPathWithExtension =
-		process.platform === "win32"
-			? relativePath.replace(/\\/g, ".")
-			: relativePath.replace(/\//g, ".");
-	const dottedPath = dottedPathWithExtension.replace(/\.py$/, "").slice(1);
+  const relativePath = params.currentFilePath.replace(params.rootPath, "");
+  const dottedPathWithExtension =
+    process.platform === "win32" ? relativePath.replace(/\\/g, ".") : relativePath.replace(/\//g, ".");
+  const dottedPath = dottedPathWithExtension.replace(/\.py$/, "").slice(1);
 
-	if (params.shouldAddModuleRootName) {
-		const moduleRootName = basename(params.rootPath);
-		return [moduleRootName, dottedPath].join(".");
-	}
-	return dottedPath;
+  let finalPath = dottedPath;
+  if (params.shouldAddModuleRootName) {
+    const moduleRootName = basename(params.rootPath);
+    finalPath = [moduleRootName, dottedPath].join(".");
+  }
+
+  if (params.omitRootPath && params.omitRootPath.length > 0) {
+    // Handle omission of root path
+    if (finalPath === params.omitRootPath) {
+      // If the path is exactly the omitRootPath, return empty string
+      finalPath = "";
+    } else if (finalPath.startsWith(`${params.omitRootPath}.`)) {
+      // If the path starts with omitRootPath followed by a dot, remove that prefix
+      finalPath = finalPath.slice(params.omitRootPath.length + 1);
+    }
+  }
+
+  return finalPath;
 };

--- a/src/utils/getImportedSymbolMap.spec.ts
+++ b/src/utils/getImportedSymbolMap.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { getImportedSymbolMap } from "./getImportedSymbolMap";
+
+describe("getImportedSymbolMap", () => {
+  it("should parse from-import statements", () => {
+    const sourceCode = `
+from module.path import Symbol, AnotherSymbol
+from another.module import ThirdSymbol as Alias
+    `.trim();
+
+    const symbolMap = getImportedSymbolMap(sourceCode);
+
+    expect(symbolMap.get("Symbol")).toBe("module.path.Symbol");
+    expect(symbolMap.get("AnotherSymbol")).toBe("module.path.AnotherSymbol");
+    expect(symbolMap.get("Alias")).toBe("another.module.ThirdSymbol");
+  });
+
+  it("should parse import statements", () => {
+    const sourceCode = `
+import module.path.Symbol
+import another.module.ThirdSymbol as Alias
+    `.trim();
+
+    const symbolMap = getImportedSymbolMap(sourceCode);
+
+    expect(symbolMap.get("Symbol")).toBe("module.path.Symbol");
+    expect(symbolMap.get("Alias")).toBe("another.module.ThirdSymbol");
+  });
+
+  it("should handle multiple import statements", () => {
+    const sourceCode = `
+import os, sys
+from typing import List, Optional, Dict
+import json as JSON
+    `.trim();
+
+    const symbolMap = getImportedSymbolMap(sourceCode);
+
+    expect(symbolMap.get("os")).toBe("os");
+    expect(symbolMap.get("sys")).toBe("sys");
+    expect(symbolMap.get("List")).toBe("typing.List");
+    expect(symbolMap.get("Optional")).toBe("typing.Optional");
+    expect(symbolMap.get("Dict")).toBe("typing.Dict");
+    expect(symbolMap.get("JSON")).toBe("json");
+  });
+
+  it("should handle complex examples", () => {
+    const sourceCode = `
+from ml_service.lms.models.course_builder import CreateCourseQuizRequest
+import pandas as pd, numpy as np
+    `.trim();
+
+    const symbolMap = getImportedSymbolMap(sourceCode);
+
+    expect(symbolMap.get("CreateCourseQuizRequest")).toBe(
+      "ml_service.lms.models.course_builder.CreateCourseQuizRequest"
+    );
+    expect(symbolMap.get("pd")).toBe("pandas");
+    expect(symbolMap.get("np")).toBe("numpy");
+  });
+});

--- a/src/utils/getImportedSymbolMap.ts
+++ b/src/utils/getImportedSymbolMap.ts
@@ -1,0 +1,73 @@
+/**
+ * Creates a map of imported symbols to their full dotted paths.
+ * @param sourceCode - The entire source code as a string.
+ * @returns A map of local symbols to their fully qualified dotted paths.
+ */
+export const getImportedSymbolMap = (sourceCode: string): Map<string, string> => {
+  const lines = sourceCode.split("\n");
+  const symbolMap = new Map<string, string>();
+
+  // Two main types of import statements:
+  // 1. from module.path import Symbol, AnotherSymbol
+  // 2. import module.path.Symbol as alias
+
+  // Regex for "from X import Y" pattern
+  const fromImportRegex = /^\s*from\s+([\w.]+)\s+import\s+(.+)$/;
+
+  // Regex for "import X" pattern
+  const importRegex = /^\s*import\s+(.+)$/;
+
+  for (const line of lines) {
+    // Handle "from X import Y" pattern
+    const fromMatch = line.match(fromImportRegex);
+    if (fromMatch) {
+      const modulePath = fromMatch[1];
+      // Parse imported symbols (handling potential commas and 'as' aliases)
+      const importedSymbolsPart = fromMatch[2];
+      const importedSymbols = importedSymbolsPart.split(",").map((s) => s.trim());
+
+      for (const symbolPart of importedSymbols) {
+        if (!symbolPart) continue;
+
+        // Handle potential "as" alias
+        const asMatch = symbolPart.match(/^([\w]+)(?:\s+as\s+([\w]+))?$/);
+        if (asMatch) {
+          const originalSymbol = asMatch[1];
+          const aliasSymbol = asMatch[2] || originalSymbol; // Use the original name if no alias
+          symbolMap.set(aliasSymbol, `${modulePath}.${originalSymbol}`);
+        }
+      }
+      continue;
+    }
+
+    // Handle "import X" pattern
+    const importMatch = line.match(importRegex);
+    if (importMatch) {
+      const importedPart = importMatch[1];
+      const imports = importedPart.split(",").map((s) => s.trim());
+
+      for (const importPart of imports) {
+        if (!importPart) continue;
+
+        // Handle "import module.path.Symbol as alias"
+        const asMatch = importPart.match(/^([\w.]+)(?:\s+as\s+([\w]+))?$/);
+        if (asMatch) {
+          const fullPath = asMatch[1];
+          const alias = asMatch[2];
+
+          if (alias) {
+            // If there's an alias, map it to the full path
+            symbolMap.set(alias, fullPath);
+          } else {
+            // If no alias, extract the last part of the path as symbol
+            const parts = fullPath.split(".");
+            const lastPart = parts[parts.length - 1];
+            symbolMap.set(lastPart, fullPath);
+          }
+        }
+      }
+    }
+  }
+
+  return symbolMap;
+};

--- a/src/utils/getRelatedDefinedSymbols.ts
+++ b/src/utils/getRelatedDefinedSymbols.ts
@@ -1,4 +1,3 @@
-
 const symbolRegex = /^(\s*)(?:class|def)\s+([a-zA-Z_][a-zA-Z0-9_]*)/;
 
 /**
@@ -8,28 +7,28 @@ const symbolRegex = /^(\s*)(?:class|def)\s+([a-zA-Z_][a-zA-Z0-9_]*)/;
  * @returns An array of symbols defined before the current line in hierarchical order.
  */
 export const getRelatedDefinedSymbols = (
-    sourceCode: string,
-    currentLine: number,
+	sourceCode: string,
+	currentLine: number,
 ): string[] => {
-    const lines = sourceCode.split('\n');
-    const definedSymbols: string[] = [];
-    let currentIndentLevel = -1;
+	const lines = sourceCode.split("\n");
+	const definedSymbols: string[] = [];
+	let currentIndentLevel = -1;
 
-    for (let i = currentLine; i >= 0; i--) {
-        const match = lines[i].match(symbolRegex);
-        if (match) {
-            const [, indent, symbol] = match;
-            const indentLevel = indent.length;
+	for (let i = currentLine; i >= 0; i--) {
+		const match = lines[i].match(symbolRegex);
+		if (match) {
+			const [, indent, symbol] = match;
+			const indentLevel = indent.length;
 
-            if (i === currentLine) {
-                definedSymbols.push(symbol);
-                currentIndentLevel = indentLevel;
-            } else if (indentLevel < currentIndentLevel) {
-                definedSymbols.unshift(symbol);
-                currentIndentLevel = indentLevel;
-            }
-        }
-    }
+			if (i === currentLine) {
+				definedSymbols.push(symbol);
+				currentIndentLevel = indentLevel;
+			} else if (indentLevel < currentIndentLevel) {
+				definedSymbols.unshift(symbol);
+				currentIndentLevel = indentLevel;
+			}
+		}
+	}
 
-    return definedSymbols;
+	return definedSymbols;
 };

--- a/src/utils/getSymbolAtPosition.spec.ts
+++ b/src/utils/getSymbolAtPosition.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getSymbolAtPosition } from "./getSymbolAtPosition";
+
+describe("getSymbolAtPosition", () => {
+  it("should find a symbol at the cursor position", () => {
+    const line = "data = CreateCourseQuizRequest(**json.loads(request.body))";
+
+    // Cursor at the beginning of a symbol
+    expect(getSymbolAtPosition(line, 7)).toBe("CreateCourseQuizRequest");
+
+    // Cursor in the middle of a symbol
+    expect(getSymbolAtPosition(line, 15)).toBe("CreateCourseQuizRequest");
+
+    // Cursor at the end of a symbol
+    expect(getSymbolAtPosition(line, 28)).toBe("CreateCourseQuizRequest");
+  });
+
+  it("should return undefined when cursor is not on a symbol", () => {
+    const line = "data = CreateCourseQuizRequest(**json.loads(request.body))";
+
+    // Cursor on whitespace
+    expect(getSymbolAtPosition(line, 6)).toBeUndefined();
+
+    // Cursor on a special character (parenthesis)
+    expect(getSymbolAtPosition(line, 30)).toBeUndefined();
+  });
+
+  it("should handle edge cases", () => {
+    // Empty line
+    expect(getSymbolAtPosition("", 0)).toBeUndefined();
+
+    // Out of bounds position
+    expect(getSymbolAtPosition("symbol", 10)).toBeUndefined();
+    expect(getSymbolAtPosition("symbol", -1)).toBeUndefined();
+
+    // Single character symbol
+    expect(getSymbolAtPosition("x = 1", 0)).toBe("x");
+  });
+});

--- a/src/utils/getSymbolAtPosition.ts
+++ b/src/utils/getSymbolAtPosition.ts
@@ -1,0 +1,42 @@
+/**
+ * Find the symbol at the current cursor position.
+ * @param text - The text of the current line.
+ * @param column - The column position (0-based) of the cursor.
+ * @returns The symbol at the current position, or undefined if not found.
+ */
+export const getSymbolAtPosition = (text: string, column: number): string | undefined => {
+  // If cursor is outside the text boundary, return undefined
+  if (column < 0 || column >= text.length) {
+    return undefined;
+  }
+
+  // Regex for valid Python identifier characters
+  const identifierChar = /[a-zA-Z0-9_]/;
+
+  // First check if the cursor is directly on an identifier character
+  if (!identifierChar.test(text[column])) {
+    return undefined;
+  }
+
+  // Find the start of the symbol (going left from cursor)
+  let start = column;
+  while (start > 0 && identifierChar.test(text[start - 1])) {
+    start--;
+  }
+
+  // Find the end of the symbol (going right from cursor)
+  let end = column;
+  while (end < text.length && identifierChar.test(text[end])) {
+    end++;
+  }
+
+  // Extract the symbol
+  const symbol = text.substring(start, end);
+
+  // If the symbol is empty or not a valid identifier, return undefined
+  if (!symbol || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(symbol)) {
+    return undefined;
+  }
+
+  return symbol;
+};


### PR DESCRIPTION
Adding some new functionality (and tests)
- New configuration option `copyPythonPath.omitRootPath` to omit specific root paths from the dotted path
- New functionality to copy the full dotted path of imported symbols
- Support for generating import statements for imported symbols